### PR TITLE
Adjust to current node version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
 language: node_js
-node_js: 5
+node_js: 12
 after_script: NODE_ENV=test istanbul cover ./node_modules/mocha/bin/_mocha --report lcovonly -- -R spec && cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js && rm -rf ./coverage
 

--- a/index.js
+++ b/index.js
@@ -3,6 +3,7 @@
 const path = require('path')
 
 module.exports = (p) => {
+  
   if (p.startsWith(`.${path.sep}`) || p.startsWith(`..${path.sep}`)) {
     p = path.resolve(path.dirname(module.parent.filename), p)
   }
@@ -10,7 +11,12 @@ module.exports = (p) => {
   try {
     return require(p)
   } catch (err) {
-    if (err.code === 'MODULE_NOT_FOUND' && ~err.message.indexOf(p)) return undefined
-    else throw err
+    if (err.code === 'MODULE_NOT_FOUND') {
+      const match = err.message.match(/Cannot find module '(.*?)'/)
+      if (match !== null && [p, p.replace(/\\/g, '\\\\')].includes(match[1])) {
+        return undefined
+      }
+    }
+    throw err
   }
 }

--- a/index.js
+++ b/index.js
@@ -3,7 +3,6 @@
 const path = require('path')
 
 module.exports = (p) => {
-  
   if (p.startsWith(`.${path.sep}`) || p.startsWith(`..${path.sep}`)) {
     p = path.resolve(path.dirname(module.parent.filename), p)
   }


### PR DESCRIPTION
In fact the current implementation does not work with current node versions. One test crashes. This PR fixes the issue and also adds support for double backslashes, which are valid in windows environments.